### PR TITLE
Fix linking on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ You can build the binaries using "lime rebuild"
 
     lime rebuild gamecenter ios
 
-For mac you need to add this to ```mac-toolchain.xml``` in ```linker id="dll"```
-```
-  <flag value="-framework"/>
-  <flag value="Gamekit"/>
-```
-
 To return to release builds:
 
     haxelib dev gamecenter

--- a/project/Build.xml
+++ b/project/Build.xml
@@ -15,9 +15,6 @@
 		<compilerflag value="-Imacos/include"/>
 		<compilerflag value="-Iinclude"/>
 
-		<flag value="-framework"/>
-		<flag value="Gamekit"/>
-		
 		<file name="mac/GameCenter.mm"/>
 		
 	</files>
@@ -40,7 +37,11 @@
 		<files id="common"/>
 		<files id="iphone" if="iphone"/>
 		<files id="mac" if="mac"/>
-		
+
+		<section if="macos">
+			<vflag name="-framework" value="GameKit" />
+		</section>
+
 	</target>
 	
 	<target id="default">


### PR DESCRIPTION
This adds the correct -framework flag to the mac build so that the extension can build properly (without changing hxcpp files).